### PR TITLE
fix: Если при перемещении ноды быстро двигать мышкой, то нода останав…

### DIFF
--- a/js/diagram.js
+++ b/js/diagram.js
@@ -157,7 +157,7 @@ export class Diagram {
     });
 
     // процесс перемещения ноды
-    this.wrapperDom.addEventListener('mousemove', (event) => {
+    window.addEventListener('mousemove', (event) => {
       if (!this.movingNode) {
         return;
       }


### PR DESCRIPTION
…ливается

Это было из-за того, что событие mouseMove отлавливалось на элементе-контейнере блок-схемы. Т.к. у этого элемента нулевая высота, то событие происходило только если указатель мыши находится над нодами, либо рёбрами. Исправил это, повесив обработчик на window